### PR TITLE
feat(#3): add env variable option for delaying functions

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,9 +10,15 @@ It starts the Tailscale daemon and connects to the Tailscale
 network exposing a SOCKS5 proxy on port 1050 (`socks://localhost:1055`) to be accessed by the main Lambda runtime
 process.
 
-The Lambda function using this layer requires the following Environment Variables:
+The Lambda function using this layer supports the following environment variables:
+
+Required:
 - `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the Tailscale API Key.
 - `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console.
+
+Optional:
+- `TS_FUNCTION_DELAY` - The delay (in milliseconds) to apply prior to function invocation. (see [this issue](https://github.com/rehanvdm/tailscale-lambda-extension/issues/3) for more details)
+  - **Default: 0**
 
 #### Initializers <a name="Initializers" id="tailscale-lambda-extension.TailscaleLambdaExtension.Initializer"></a>
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ npm install tailscale-lambda-extension
 
 ## Usage
 
-The Lambda function using this layer requires the following Environment Variables:
-- `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the pure text Tailscale API Key.
-- `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console that identifies the Lambda function.
+The Lambda function using this layer supports the following environment variables:
+
+Required:
+- `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the Tailscale API Key.
+- `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console.
+
+Optional:
+- `TS_FUNCTION_DELAY` - The delay (in milliseconds) to apply prior to function invocation. (see [this issue](https://github.com/rehanvdm/tailscale-lambda-extension/issues/3) for more details)
+  - **Default: 0**
 
 ```typescript
 import * as cdk from 'aws-cdk-lib';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,15 @@ export interface TailscaleLambdaExtensionProps {
  * network exposing a SOCKS5 proxy on port 1050 (`socks://localhost:1055`) to be accessed by the main Lambda runtime
  * process.
  *
- * The Lambda function using this layer requires the following Environment Variables:
+ * The Lambda function using this layer supports the following environment variables:
+ *
+ * Required:
  * - `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the Tailscale API Key.
  * - `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console.
+ *
+ * Optional:
+ * - `TS_FUNCTION_DELAY` - The delay (in milliseconds) to apply prior to function invocation. (see [this issue](https://github.com/rehanvdm/tailscale-lambda-extension/issues/3) for more details)
+ *   - **Default: 0**
  */
 export class TailscaleLambdaExtension extends Construct {
   public readonly layer: lambda.LayerVersion;

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -92,4 +92,6 @@ do
     exit 0 # Exit if we receive a SHUTDOWN event
   fi
 
+  sleep "$(awk "BEGIN {print ${TS_FUNCTION_DELAY:-0} / 1000}")"
+
 done


### PR DESCRIPTION
fixes #3.

Add delay prior to function invocation to allow tailscale and socks to be fully ready prior to invoking a lambda.