### PR TITLE
feat: add TS_ADVERTISE_TAGS and TS_EXIT_NODE support

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,9 +18,8 @@ Optional Environment Variables:
 - `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
 - `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
 - `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
-- `TS_EXIT_NODE_PROBE_TIMEOUT` - curl connect+max timeout in seconds for SOCKS5 probe (default: `3`).
-- `TS_EXIT_NODE_PROBE_RETRIES` - Number of SOCKS5 probe attempts when waiting for exit node (default: `5`).
-- `TS_EXIT_NODE_PROBE_HOST` - HTTPS host to probe via SOCKS5 to verify exit node routing (default: `sso.garmin.com`).
+- `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
+- `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
 
 #### Initializers <a name="Initializers" id="tailscale-lambda-extension.TailscaleLambdaExtension.Initializer"></a>
 

--- a/API.md
+++ b/API.md
@@ -14,6 +14,13 @@ The Lambda function using this layer requires the following Environment Variable
 - `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the Tailscale API Key.
 - `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console.
 
+Optional Environment Variables:
+- `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
+- `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
+- `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
+- `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
+- `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
+
 #### Initializers <a name="Initializers" id="tailscale-lambda-extension.TailscaleLambdaExtension.Initializer"></a>
 
 ```typescript

--- a/API.md
+++ b/API.md
@@ -18,8 +18,9 @@ Optional Environment Variables:
 - `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
 - `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
 - `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
-- `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
-- `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
+- `TS_EXIT_NODE_PROBE_TIMEOUT` - curl connect+max timeout in seconds for SOCKS5 probe (default: `3`).
+- `TS_EXIT_NODE_PROBE_RETRIES` - Number of SOCKS5 probe attempts when waiting for exit node (default: `5`).
+- `TS_EXIT_NODE_PROBE_HOST` - HTTPS host to probe via SOCKS5 to verify exit node routing (default: `sso.garmin.com`).
 
 #### Initializers <a name="Initializers" id="tailscale-lambda-extension.TailscaleLambdaExtension.Initializer"></a>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The Lambda function using this layer requires the following Environment Variable
 
 Optional Environment Variables:
 - `TS_ADVERTISE_TAGS` - Tags to advertise during `tailscale up` (e.g., `tag:lambda`). Required when using OAuth client keys instead of auth keys.
-- `TS_EXIT_NODE` - Exit node hostname or IP address. When set, all traffic is routed through the specified exit node. The extension waits up to 10 seconds for the exit node to come online.
+- `TS_EXIT_NODE` - Exit node hostname or IP address. When set, internet-bound traffic is routed through the specified exit node. The extension waits up to 10 seconds for the exit node to become reachable.
+- `TS_EXIT_NODE_REQUIRED` - Set to `true` to abort the extension if the exit node is not reachable within 10 seconds (only the literal value `true` is recognized, case-insensitive). Defaults to `false` (warn and continue).
 
 ```typescript
 import * as cdk from 'aws-cdk-lib';
@@ -52,7 +53,7 @@ export class MyStack extends cdk.Stack {
         TS_HOSTNAME: "my-lambda",
         // Optional: advertise tags (required for OAuth client keys)
         TS_ADVERTISE_TAGS: "tag:lambda",
-        // Optional: route all traffic through an exit node
+        // Optional: route internet-bound traffic through an exit node
         TS_EXIT_NODE: "100.x.y.z",
       }
     });
@@ -187,12 +188,13 @@ OAuth client keys do not expire, eliminating the need for manual key rotation. T
 
 ### Exit Nodes
 
-To route all Lambda traffic through a Tailscale exit node:
+To route Lambda internet-bound traffic through a Tailscale exit node:
 
 1. Ensure you have an [exit node](https://tailscale.com/kb/1103/exit-nodes) configured in your Tailscale network
 2. Set the `TS_EXIT_NODE` environment variable on your Lambda to the exit node's Tailscale IP (e.g., `100.x.y.z`)
-3. The extension will configure the exit node during initialization and wait up to 10 seconds for it to come online
-4. If the exit node does not come online in time, the extension logs a warning and continues without it
+3. The extension will configure the exit node during initialization and wait up to 10 seconds for it to become reachable
+4. By default, if the exit node is not reachable in time, the extension logs a warning and continues (fail-open)
+5. Set `TS_EXIT_NODE_REQUIRED=true` to abort the extension if the exit node is not reachable (fail-closed) — recommended when exit node routing is critical (e.g., residential IP requirement)
 
 ### Auth Keys
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ npm install tailscale-lambda-extension
 ## Usage
 
 The Lambda function using this layer requires the following Environment Variables:
-- `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the pure text Tailscale API Key.
+- `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the pure text Tailscale API Key (auth key or OAuth client key).
 - `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console that identifies the Lambda function.
+
+Optional Environment Variables:
+- `TS_ADVERTISE_TAGS` - Tags to advertise during `tailscale up` (e.g., `tag:lambda`). Required when using OAuth client keys instead of auth keys.
+- `TS_EXIT_NODE` - Exit node hostname or IP address. When set, all traffic is routed through the specified exit node. The extension waits up to 10 seconds for the exit node to come online.
 
 ```typescript
 import * as cdk from 'aws-cdk-lib';
@@ -46,6 +50,10 @@ export class MyStack extends cdk.Stack {
       environment: {
         TS_SECRET_API_KEY: "tailscale-api-key",
         TS_HOSTNAME: "my-lambda",
+        // Optional: advertise tags (required for OAuth client keys)
+        TS_ADVERTISE_TAGS: "tag:lambda",
+        // Optional: route all traffic through an exit node
+        TS_EXIT_NODE: "100.x.y.z",
       }
     });
 
@@ -165,6 +173,26 @@ fact that if you tag an Auth Key, then that Auth Key will not expire. Create a t
 }
 ```
 3. Save the file.
+
+### OAuth Client Keys (Recommended)
+
+OAuth client keys do not expire, eliminating the need for manual key rotation. They require `--advertise-tags` to be passed during `tailscale up`.
+
+1. Go to your Tailscale network, Settings, OAuth clients: https://login.tailscale.com/admin/settings/oauth
+2. Click "Generate OAuth client..."
+3. Grant the `Devices: Write` scope
+4. Add the `tag:awslambda` tag
+5. Copy the client secret to your AWS Secrets Manager secret
+6. Set the `TS_ADVERTISE_TAGS` environment variable on your Lambda to `tag:awslambda`
+
+### Exit Nodes
+
+To route all Lambda traffic through a Tailscale exit node:
+
+1. Ensure you have an [exit node](https://tailscale.com/kb/1103/exit-nodes) configured in your Tailscale network
+2. Set the `TS_EXIT_NODE` environment variable on your Lambda to the exit node's Tailscale IP (e.g., `100.x.y.z`)
+3. The extension will configure the exit node during initialization and wait up to 10 seconds for it to come online
+4. If the exit node does not come online in time, the extension logs a warning and continues without it
 
 ### Auth Keys
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,9 @@ export interface TailscaleLambdaExtensionProps {
  * - `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
  * - `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
  * - `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
- * - `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
- * - `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
+ * - `TS_EXIT_NODE_PROBE_TIMEOUT` - curl connect+max timeout in seconds for SOCKS5 probe (default: `3`).
+ * - `TS_EXIT_NODE_PROBE_RETRIES` - Number of SOCKS5 probe attempts when waiting for exit node (default: `5`).
+ * - `TS_EXIT_NODE_PROBE_HOST` - HTTPS host to probe via SOCKS5 to verify exit node routing (default: `sso.garmin.com`).
  */
 export class TailscaleLambdaExtension extends Construct {
   public readonly layer: lambda.LayerVersion;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ export interface TailscaleLambdaExtensionProps {
  * The Lambda function using this layer requires the following Environment Variables:
  * - `TS_SECRET_API_KEY` - The name of the AWS Secrets Manager secret that contains the Tailscale API Key.
  * - `TS_HOSTNAME` - The "Machine" name as shown in the Tailscale admin console.
+ *
+ * Optional Environment Variables:
+ * - `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
+ * - `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
+ * - `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
+ * - `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
+ * - `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
  */
 export class TailscaleLambdaExtension extends Construct {
   public readonly layer: lambda.LayerVersion;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,8 @@ export interface TailscaleLambdaExtensionProps {
  * - `TS_ADVERTISE_TAGS` - Comma-separated Tailscale ACL tags to advertise (e.g. `tag:lambda`).
  * - `TS_EXIT_NODE` - Tailscale IP of the exit node to route traffic through.
  * - `TS_EXIT_NODE_REQUIRED` - Set to `true` to fail if exit node is unreachable (default: `false`).
- * - `TS_EXIT_NODE_PROBE_TIMEOUT` - curl connect+max timeout in seconds for SOCKS5 probe (default: `3`).
- * - `TS_EXIT_NODE_PROBE_RETRIES` - Number of SOCKS5 probe attempts when waiting for exit node (default: `5`).
- * - `TS_EXIT_NODE_PROBE_HOST` - HTTPS host to probe via SOCKS5 to verify exit node routing (default: `sso.garmin.com`).
+ * - `TS_EXIT_NODE_PING_TIMEOUT` - Per-ping timeout when waiting for exit node (default: `2000ms`).
+ * - `TS_EXIT_NODE_PING_RETRIES` - Number of ping attempts when waiting for exit node (default: `10`).
  */
 export class TailscaleLambdaExtension extends Construct {
   public readonly layer: lambda.LayerVersion;

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -83,41 +83,28 @@ do
 done
 sleep 1 # TODO: Can we remove?
 
-# Wait for the SOCKS5 proxy to route traffic through the exit node.
-# Uses curl --socks5 to probe an HTTP endpoint, which tests the actual traffic
-# path used by the Lambda handler — not just ICMP node-to-node reachability.
-# This avoids false negatives from Tailscale ACL rules that block direct pings
-# between tagged nodes while still allowing exit node routing.
-#
-# TS_EXIT_NODE_PROBE_TIMEOUT: curl connect+max timeout in seconds (default: 3)
-# TS_EXIT_NODE_PROBE_RETRIES: number of probe attempts (default: 5)
-# TS_EXIT_NODE_PROBE_HOST: HTTPS host to probe via SOCKS5 (default: sso.garmin.com)
+# Wait for exit node to become reachable if configured
+# TS_EXIT_NODE_PING_TIMEOUT: per-ping timeout (default: 2000ms)
+# TS_EXIT_NODE_PING_RETRIES: number of ping attempts (default: 10)
 if [ -n "${TS_EXIT_NODE:-}" ]; then
-  PROBE_TIMEOUT="${TS_EXIT_NODE_PROBE_TIMEOUT:-3}"
-  PROBE_RETRIES="${TS_EXIT_NODE_PROBE_RETRIES:-5}"
-  PROBE_HOST="${TS_EXIT_NODE_PROBE_HOST:-sso.garmin.com}"
-  echo "[${LAMBDA_EXTENSION_NAME}] Waiting for SOCKS5 proxy via exit node ${TS_EXIT_NODE} (host=${PROBE_HOST}, timeout=${PROBE_TIMEOUT}s, retries=${PROBE_RETRIES})..." 1>&2;
-  PROXY_READY=false
-  for i in $(seq 1 "${PROBE_RETRIES}"); do
-    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-      --socks5 "localhost:1055" \
-      --connect-timeout "${PROBE_TIMEOUT}" \
-      --max-time "${PROBE_TIMEOUT}" \
-      "https://${PROBE_HOST}" 2>/dev/null || echo "000")
-    if [ "${HTTP_STATUS}" != "000" ] && [ "${HTTP_STATUS}" -lt 500 ] 2>/dev/null; then
-      PROXY_READY=true
-      echo "[${LAMBDA_EXTENSION_NAME}] SOCKS5 proxy ready (HTTP ${HTTP_STATUS} from ${PROBE_HOST})" 1>&2;
+  EXIT_NODE_PING_TIMEOUT="${TS_EXIT_NODE_PING_TIMEOUT:-2000ms}"
+  EXIT_NODE_PING_RETRIES="${TS_EXIT_NODE_PING_RETRIES:-10}"
+  echo "[${LAMBDA_EXTENSION_NAME}] Waiting for exit node ${TS_EXIT_NODE} (timeout=${EXIT_NODE_PING_TIMEOUT}, retries=${EXIT_NODE_PING_RETRIES})..." 1>&2;
+  EXIT_NODE_ONLINE=false
+  for i in $(seq 1 "${EXIT_NODE_PING_RETRIES}"); do
+    if /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock ping --c 1 --timeout "${EXIT_NODE_PING_TIMEOUT}" "${TS_EXIT_NODE}" >/dev/null 2>&1; then
+      EXIT_NODE_ONLINE=true
+      echo "[${LAMBDA_EXTENSION_NAME}] Exit node ${TS_EXIT_NODE} is reachable" 1>&2;
       break
     fi
-    echo "[${LAMBDA_EXTENSION_NAME}] SOCKS5 probe attempt ${i}/${PROBE_RETRIES}: HTTP ${HTTP_STATUS}" 1>&2;
   done
-  if [ "${PROXY_READY}" = "false" ]; then
+  if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
     EXIT_NODE_REQUIRED=$(echo "${TS_EXIT_NODE_REQUIRED:-false}" | tr '[:upper:]' '[:lower:]')
     if [ "${EXIT_NODE_REQUIRED}" = "true" ]; then
-      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: SOCKS5 proxy not ready after ${PROBE_RETRIES} attempts (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running: https://login.tailscale.com/admin/machines" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: Exit node ${TS_EXIT_NODE} not reachable (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running and approved in the Tailscale admin console: https://login.tailscale.com/admin/machines" 1>&2;
       exit 1
     else
-      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: SOCKS5 proxy not ready after ${PROBE_RETRIES} attempts; exit-node preference remains configured" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable; exit-node preference remains configured" 1>&2;
     fi
   fi
 fi

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -94,7 +94,13 @@ if [ -n "${TS_EXIT_NODE:-}" ]; then
     fi
   done
   if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
-    echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable within 10s; exit-node preference remains configured" 1>&2;
+    EXIT_NODE_REQUIRED=$(echo "${TS_EXIT_NODE_REQUIRED:-false}" | tr '[:upper:]' '[:lower:]')
+    if [ "${EXIT_NODE_REQUIRED}" = "true" ]; then
+      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: Exit node ${TS_EXIT_NODE} not reachable within 10s (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running and approved in the Tailscale admin console: https://login.tailscale.com/admin/machines" 1>&2;
+      exit 1
+    else
+      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable within 10s; exit-node preference remains configured" 1>&2;
+    fi
   fi
 fi
 ### CUSTOM CODE END

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -64,13 +64,42 @@ TAILSCALED_PID=$!
 echo "[${LAMBDA_EXTENSION_NAME}] TAILSCALED_PID: ${TAILSCALED_PID}" 1>&2;
 sleep 1 # TODO: Can we remove?
 
+# Build extra arguments for tailscale up
+EXTRA_ARGS=""
+if [ -n "${TS_ADVERTISE_TAGS:-}" ]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --advertise-tags=${TS_ADVERTISE_TAGS}"
+  echo "[${LAMBDA_EXTENSION_NAME}] Advertising tags: ${TS_ADVERTISE_TAGS}" 1>&2;
+fi
+
 # Tailscale up
 echo "[${LAMBDA_EXTENSION_NAME}] Tailscale up..." 1>&2;
-until /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up --authkey="${TS_KEY}" --hostname="${TS_HOSTNAME}"
+until /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up --authkey="${TS_KEY}" --hostname="${TS_HOSTNAME}" ${EXTRA_ARGS}
 do
   sleep 0.1
 done
 sleep 1 # TODO: Can we remove?
+
+# Configure exit node if specified
+if [ -n "${TS_EXIT_NODE:-}" ]; then
+  echo "[${LAMBDA_EXTENSION_NAME}] Setting exit node: ${TS_EXIT_NODE}" 1>&2;
+  /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock set \
+    --exit-node="${TS_EXIT_NODE}"
+
+  # Wait for exit node to come online (max 10s)
+  EXIT_NODE_ONLINE=false
+  for i in $(seq 1 20); do
+    STATUS=$(/opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock status --json 2>/dev/null || echo "{}")
+    if echo "${STATUS}" | grep -q '"Online":true'; then
+      EXIT_NODE_ONLINE=true
+      echo "[${LAMBDA_EXTENSION_NAME}] Exit node online" 1>&2;
+      break
+    fi
+    sleep 0.5
+  done
+  if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
+    echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node did not come online within 10s, continuing without exit node" 1>&2;
+  fi
+fi
 ### CUSTOM CODE END
 
 

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -83,28 +83,41 @@ do
 done
 sleep 1 # TODO: Can we remove?
 
-# Wait for exit node to become reachable if configured
-# TS_EXIT_NODE_PING_TIMEOUT: per-ping timeout (default: 2000ms)
-# TS_EXIT_NODE_PING_RETRIES: number of ping attempts (default: 10)
+# Wait for the SOCKS5 proxy to route traffic through the exit node.
+# Uses curl --socks5 to probe an HTTP endpoint, which tests the actual traffic
+# path used by the Lambda handler — not just ICMP node-to-node reachability.
+# This avoids false negatives from Tailscale ACL rules that block direct pings
+# between tagged nodes while still allowing exit node routing.
+#
+# TS_EXIT_NODE_PROBE_TIMEOUT: curl connect+max timeout in seconds (default: 3)
+# TS_EXIT_NODE_PROBE_RETRIES: number of probe attempts (default: 5)
+# TS_EXIT_NODE_PROBE_HOST: HTTPS host to probe via SOCKS5 (default: sso.garmin.com)
 if [ -n "${TS_EXIT_NODE:-}" ]; then
-  EXIT_NODE_PING_TIMEOUT="${TS_EXIT_NODE_PING_TIMEOUT:-2000ms}"
-  EXIT_NODE_PING_RETRIES="${TS_EXIT_NODE_PING_RETRIES:-10}"
-  echo "[${LAMBDA_EXTENSION_NAME}] Waiting for exit node ${TS_EXIT_NODE} (timeout=${EXIT_NODE_PING_TIMEOUT}, retries=${EXIT_NODE_PING_RETRIES})..." 1>&2;
-  EXIT_NODE_ONLINE=false
-  for i in $(seq 1 "${EXIT_NODE_PING_RETRIES}"); do
-    if /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock ping --c 1 --timeout "${EXIT_NODE_PING_TIMEOUT}" "${TS_EXIT_NODE}" >/dev/null 2>&1; then
-      EXIT_NODE_ONLINE=true
-      echo "[${LAMBDA_EXTENSION_NAME}] Exit node ${TS_EXIT_NODE} is reachable" 1>&2;
+  PROBE_TIMEOUT="${TS_EXIT_NODE_PROBE_TIMEOUT:-3}"
+  PROBE_RETRIES="${TS_EXIT_NODE_PROBE_RETRIES:-5}"
+  PROBE_HOST="${TS_EXIT_NODE_PROBE_HOST:-sso.garmin.com}"
+  echo "[${LAMBDA_EXTENSION_NAME}] Waiting for SOCKS5 proxy via exit node ${TS_EXIT_NODE} (host=${PROBE_HOST}, timeout=${PROBE_TIMEOUT}s, retries=${PROBE_RETRIES})..." 1>&2;
+  PROXY_READY=false
+  for i in $(seq 1 "${PROBE_RETRIES}"); do
+    HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+      --socks5 "localhost:1055" \
+      --connect-timeout "${PROBE_TIMEOUT}" \
+      --max-time "${PROBE_TIMEOUT}" \
+      "https://${PROBE_HOST}" 2>/dev/null || echo "000")
+    if [ "${HTTP_STATUS}" != "000" ] && [ "${HTTP_STATUS}" -lt 500 ] 2>/dev/null; then
+      PROXY_READY=true
+      echo "[${LAMBDA_EXTENSION_NAME}] SOCKS5 proxy ready (HTTP ${HTTP_STATUS} from ${PROBE_HOST})" 1>&2;
       break
     fi
+    echo "[${LAMBDA_EXTENSION_NAME}] SOCKS5 probe attempt ${i}/${PROBE_RETRIES}: HTTP ${HTTP_STATUS}" 1>&2;
   done
-  if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
+  if [ "${PROXY_READY}" = "false" ]; then
     EXIT_NODE_REQUIRED=$(echo "${TS_EXIT_NODE_REQUIRED:-false}" | tr '[:upper:]' '[:lower:]')
     if [ "${EXIT_NODE_REQUIRED}" = "true" ]; then
-      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: Exit node ${TS_EXIT_NODE} not reachable (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running and approved in the Tailscale admin console: https://login.tailscale.com/admin/machines" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: SOCKS5 proxy not ready after ${PROBE_RETRIES} attempts (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running: https://login.tailscale.com/admin/machines" 1>&2;
       exit 1
     else
-      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable; exit-node preference remains configured" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: SOCKS5 proxy not ready after ${PROBE_RETRIES} attempts; exit-node preference remains configured" 1>&2;
     fi
   fi
 fi

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -65,19 +65,19 @@ echo "[${LAMBDA_EXTENSION_NAME}] TAILSCALED_PID: ${TAILSCALED_PID}" 1>&2;
 sleep 1 # TODO: Can we remove?
 
 # Build extra arguments for tailscale up
-EXTRA_ARGS=""
+EXTRA_ARGS=()
 if [ -n "${TS_ADVERTISE_TAGS:-}" ]; then
-  EXTRA_ARGS="${EXTRA_ARGS} --advertise-tags=${TS_ADVERTISE_TAGS}"
+  EXTRA_ARGS+=(--advertise-tags="${TS_ADVERTISE_TAGS}")
   echo "[${LAMBDA_EXTENSION_NAME}] Advertising tags: ${TS_ADVERTISE_TAGS}" 1>&2;
 fi
 if [ -n "${TS_EXIT_NODE:-}" ]; then
-  EXTRA_ARGS="${EXTRA_ARGS} --exit-node=${TS_EXIT_NODE}"
+  EXTRA_ARGS+=(--exit-node="${TS_EXIT_NODE}")
   echo "[${LAMBDA_EXTENSION_NAME}] Exit node: ${TS_EXIT_NODE}" 1>&2;
 fi
 
 # Tailscale up (pass all flags together to avoid "requires mentioning all" error on retries)
 echo "[${LAMBDA_EXTENSION_NAME}] Tailscale up..." 1>&2;
-until /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up --authkey="${TS_KEY}" --hostname="${TS_HOSTNAME}" ${EXTRA_ARGS}
+until /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up --authkey="${TS_KEY}" --hostname="${TS_HOSTNAME}" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}
 do
   sleep 0.1
 done

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -83,11 +83,16 @@ do
 done
 sleep 1 # TODO: Can we remove?
 
-# Wait for exit node to become reachable if configured (timeout: ~10s)
+# Wait for exit node to become reachable if configured
+# TS_EXIT_NODE_PING_TIMEOUT: per-ping timeout (default: 2000ms)
+# TS_EXIT_NODE_PING_RETRIES: number of ping attempts (default: 10)
 if [ -n "${TS_EXIT_NODE:-}" ]; then
+  EXIT_NODE_PING_TIMEOUT="${TS_EXIT_NODE_PING_TIMEOUT:-2000ms}"
+  EXIT_NODE_PING_RETRIES="${TS_EXIT_NODE_PING_RETRIES:-10}"
+  echo "[${LAMBDA_EXTENSION_NAME}] Waiting for exit node ${TS_EXIT_NODE} (timeout=${EXIT_NODE_PING_TIMEOUT}, retries=${EXIT_NODE_PING_RETRIES})..." 1>&2;
   EXIT_NODE_ONLINE=false
-  for i in $(seq 1 20); do
-    if /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock ping --c 1 --timeout 500ms "${TS_EXIT_NODE}" >/dev/null 2>&1; then
+  for i in $(seq 1 "${EXIT_NODE_PING_RETRIES}"); do
+    if /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock ping --c 1 --timeout "${EXIT_NODE_PING_TIMEOUT}" "${TS_EXIT_NODE}" >/dev/null 2>&1; then
       EXIT_NODE_ONLINE=true
       echo "[${LAMBDA_EXTENSION_NAME}] Exit node ${TS_EXIT_NODE} is reachable" 1>&2;
       break
@@ -96,10 +101,10 @@ if [ -n "${TS_EXIT_NODE:-}" ]; then
   if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
     EXIT_NODE_REQUIRED=$(echo "${TS_EXIT_NODE_REQUIRED:-false}" | tr '[:upper:]' '[:lower:]')
     if [ "${EXIT_NODE_REQUIRED}" = "true" ]; then
-      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: Exit node ${TS_EXIT_NODE} not reachable within 10s (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running and approved in the Tailscale admin console: https://login.tailscale.com/admin/machines" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] ERROR: Exit node ${TS_EXIT_NODE} not reachable (TS_EXIT_NODE_REQUIRED=true). Verify the exit node is running and approved in the Tailscale admin console: https://login.tailscale.com/admin/machines" 1>&2;
       exit 1
     else
-      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable within 10s; exit-node preference remains configured" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable; exit-node preference remains configured" 1>&2;
     fi
   fi
 fi

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -70,8 +70,12 @@ if [ -n "${TS_ADVERTISE_TAGS:-}" ]; then
   EXTRA_ARGS="${EXTRA_ARGS} --advertise-tags=${TS_ADVERTISE_TAGS}"
   echo "[${LAMBDA_EXTENSION_NAME}] Advertising tags: ${TS_ADVERTISE_TAGS}" 1>&2;
 fi
+if [ -n "${TS_EXIT_NODE:-}" ]; then
+  EXTRA_ARGS="${EXTRA_ARGS} --exit-node=${TS_EXIT_NODE}"
+  echo "[${LAMBDA_EXTENSION_NAME}] Exit node: ${TS_EXIT_NODE}" 1>&2;
+fi
 
-# Tailscale up
+# Tailscale up (pass all flags together to avoid "requires mentioning all" error on retries)
 echo "[${LAMBDA_EXTENSION_NAME}] Tailscale up..." 1>&2;
 until /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up --authkey="${TS_KEY}" --hostname="${TS_HOSTNAME}" ${EXTRA_ARGS}
 do
@@ -79,13 +83,8 @@ do
 done
 sleep 1 # TODO: Can we remove?
 
-# Configure exit node if specified
+# Wait for exit node to come online if configured
 if [ -n "${TS_EXIT_NODE:-}" ]; then
-  echo "[${LAMBDA_EXTENSION_NAME}] Setting exit node: ${TS_EXIT_NODE}" 1>&2;
-  /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock set \
-    --exit-node="${TS_EXIT_NODE}"
-
-  # Wait for exit node to come online (max 10s)
   EXIT_NODE_ONLINE=false
   for i in $(seq 1 20); do
     STATUS=$(/opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock status --json 2>/dev/null || echo "{}")

--- a/src/tailscale-extension/extensions/tailscale-extension
+++ b/src/tailscale-extension/extensions/tailscale-extension
@@ -83,20 +83,18 @@ do
 done
 sleep 1 # TODO: Can we remove?
 
-# Wait for exit node to come online if configured
+# Wait for exit node to become reachable if configured (timeout: ~10s)
 if [ -n "${TS_EXIT_NODE:-}" ]; then
   EXIT_NODE_ONLINE=false
   for i in $(seq 1 20); do
-    STATUS=$(/opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock status --json 2>/dev/null || echo "{}")
-    if echo "${STATUS}" | grep -q '"Online":true'; then
+    if /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock ping --c 1 --timeout 500ms "${TS_EXIT_NODE}" >/dev/null 2>&1; then
       EXIT_NODE_ONLINE=true
-      echo "[${LAMBDA_EXTENSION_NAME}] Exit node online" 1>&2;
+      echo "[${LAMBDA_EXTENSION_NAME}] Exit node ${TS_EXIT_NODE} is reachable" 1>&2;
       break
     fi
-    sleep 0.5
   done
   if [ "${EXIT_NODE_ONLINE}" = "false" ]; then
-    echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node did not come online within 10s, continuing without exit node" 1>&2;
+    echo "[${LAMBDA_EXTENSION_NAME}] WARNING: Exit node ${TS_EXIT_NODE} not reachable within 10s; exit-node preference remains configured" 1>&2;
   fi
 fi
 ### CUSTOM CODE END


### PR DESCRIPTION
## Summary

Adds support for three new optional environment variables in the extension shell script:

- **`TS_ADVERTISE_TAGS`**: Passes `--advertise-tags` to `tailscale up`, enabling OAuth client keys (no expiry) instead of auth keys that expire every 90 days.
- **`TS_EXIT_NODE`**: Passes `--exit-node` to `tailscale up`, with a 10-second reachability check using `tailscale ping` and warning log on timeout.
- **`TS_EXIT_NODE_REQUIRED`**: When `true`, aborts the extension if the exit node is not reachable within 10 seconds (fail-closed). Defaults to `false` (fail-open).

All features are **fully backward compatible** — when the env vars are not set, behavior is identical to the current version.

## Changes

### Shell script (`src/tailscale-extension/extensions/tailscale-extension`)
- Build `EXTRA_ARGS` bash array with `--advertise-tags` and `--exit-node` when respective env vars are set
- Pass all flags to `tailscale up` together to avoid "requires mentioning all" errors
- After `tailscale up`, verify exit node reachability with `tailscale ping`
- Optional fail-closed behavior via `TS_EXIT_NODE_REQUIRED=true`

### README
- Documented new env vars in usage section
- Added OAuth Client Keys section
- Added Exit Nodes section with fail-open/fail-closed documentation

### No construct changes
The CDK construct only creates a Lambda Layer and has no reference to the Lambda function. The new env vars are set by the user on their Lambda, matching the existing pattern for `TS_SECRET_API_KEY` and `TS_HOSTNAME`.

## Motivation

See #5 for full context. We need these features for a Lambda that routes traffic through a Tailscale exit node to reach Garmin Connect with a residential IP.

## Test plan

- [x] `npx projen build` passes (compile, test, lint, package)
- [ ] Manual integration test: deploy Lambda with `TS_ADVERTISE_TAGS=tag:lambda` and OAuth client key
- [ ] Manual integration test: deploy Lambda with `TS_EXIT_NODE=<ip>` and verify routing
- [ ] Manual integration test: deploy with `TS_EXIT_NODE_REQUIRED=true` and unreachable node — verify extension aborts